### PR TITLE
fix: update testnet to goerli 

### DIFF
--- a/ape_arbitrum/__init__.py
+++ b/ape_arbitrum/__init__.py
@@ -21,10 +21,11 @@ def ecosystems():
 def networks():
     for network_name, network_params in NETWORKS.items():
         yield "arbitrum", network_name, create_network_type(*network_params)
+        yield "arbitrum", f"{network_name}-fork", NetworkAPI
 
     # NOTE: This works for development providers, as they get chain_id from themselves
     yield "arbitrum", LOCAL_NETWORK_NAME, NetworkAPI
-    yield "arbitrum", "mainnet-fork", NetworkAPI
+
 
 
 @plugins.register(plugins.ProviderPlugin)

--- a/ape_arbitrum/__init__.py
+++ b/ape_arbitrum/__init__.py
@@ -27,7 +27,6 @@ def networks():
     yield "arbitrum", LOCAL_NETWORK_NAME, NetworkAPI
 
 
-
 @plugins.register(plugins.ProviderPlugin)
 def providers():
     for network_name in NETWORKS:

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -37,6 +37,10 @@ class Arbitrum(Ethereum):
     def create_transaction(self, **kwargs) -> TransactionAPI:
         """
         Returns a transaction using the given constructor kwargs.
+        Overridden because does not support
+
+        **kwargs: Kwargs for the transaction class.
+
         Returns:
             :class:`~ape.api.transactions.TransactionAPI`
         """

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -23,9 +23,27 @@ class ApeArbitrumError(ApeException):
     """
 
 
+def _create_network_config(
+    required_confirmations: int = 1, block_time: int = 1, **kwargs
+) -> NetworkConfig:
+    # Helper method to isolate `type: ignore` comments.
+    return NetworkConfig(
+        required_confirmations=required_confirmations, block_time=block_time, **kwargs
+    )  # type: ignore
+
+
+def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfig:
+    return _create_network_config(
+        required_confirmations=0, block_time=0, default_provider=default_provider
+    )
+
+
 class ArbitrumConfig(PluginConfig):
-    mainnet: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=1)  # type: ignore
-    local: NetworkConfig = NetworkConfig(default_provider="test")  # type: ignore
+    mainnet: NetworkConfig = _create_network_config()
+    mainnet_fork: NetworkConfig = _create_local_config()
+    goerli: NetworkConfig = _create_network_config()
+    goerli_fork: NetworkConfig = _create_local_config()
+    local: NetworkConfig = _create_local_config(default_provider="test")
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -2,6 +2,7 @@ from typing import Optional, Type, Union, cast
 
 from ape.api import TransactionAPI
 from ape.api.config import PluginConfig
+from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import ApeException
 from ape.types import TransactionSignature
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
@@ -25,7 +26,7 @@ class ApeArbitrumError(ApeException):
 class ArbitrumConfig(PluginConfig):
     mainnet: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=1)  # type: ignore
     local: NetworkConfig = NetworkConfig(default_provider="test")  # type: ignore
-    default_network: str = "mainnet"
+    default_network: str = LOCAL_NETWORK_NAME
 
 
 class Arbitrum(Ethereum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 addopts = """
-    -n auto
     -p no:ape_test
     --cov-branch
     --cov-report term

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     url="https://github.com/ApeWorX/ape-arbitrum",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.5.0,<0.6",
+        "eth-ape>=0.5.2,<0.6",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

The original testnet was based on Rinkeby.
That one is gone now!
This PR updates the plugin to use the Goerli based testnet.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
