### PR TITLE
feat: digest input as a hex string rather than bytes

### DIFF
--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -80,7 +80,7 @@ class Arbitrum(Ethereum):
             kwargs["chainId"] = int(kwargs["chainId"], 16)
 
         if "input" in kwargs:
-            kwargs["data"] = decode_hex(kwargs.pop("input"))
+            kwargs["data"] = decode_hex(kwargs.pop("input").hex())
 
         if all(field in kwargs for field in ("v", "r", "s")):
             kwargs["signature"] = TransactionSignature(  # type: ignore


### PR DESCRIPTION
Fixes #6 

```
$ ape console --network arbitrum
WARNING: Connecting Geth plugin to non-Geth client 'nitro'.

In [1]: tx = networks.provider.get_receipt('0x1c38688523bf47921fef5551451fefa6e2e5d77991ea674d572f02d72dda4dc7')

In [2]: tx.data.hex()
Out[2]: '2e1a7d4d00000000000000000000000000000000000000000000000008e70535946b0a24'
```