### PR TITLE
feat: support dynamic type txs

### DIFF
--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -6,7 +6,7 @@ from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import ApeException
 from ape.types import TransactionSignature
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
-from ape_ethereum.transactions import StaticFeeTransaction, DynamicFeeTransaction, TransactionType
+from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
 from eth_typing import HexStr
 from eth_utils import add_0x_prefix, decode_hex
 

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -6,7 +6,7 @@ from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import ApeException
 from ape.types import TransactionSignature
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
-from ape_ethereum.transactions import StaticFeeTransaction, TransactionType
+from ape_ethereum.transactions import StaticFeeTransaction, DynamicFeeTransaction, TransactionType
 from eth_typing import HexStr
 from eth_utils import add_0x_prefix, decode_hex
 
@@ -113,6 +113,7 @@ def _get_transaction_type(_type: Optional[Union[int, str, bytes]]) -> Transactio
 def _get_transaction_cls(transaction_type: TransactionType) -> Type[TransactionAPI]:
     transaction_types = {
         TransactionType.STATIC: StaticFeeTransaction,
+        TransactionType.DYNAMIC: DynamicFeeTransaction
     }
     if transaction_type not in transaction_types:
         raise ApeArbitrumError(f"Transaction type '{transaction_type}' not supported.")

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -113,7 +113,7 @@ def _get_transaction_type(_type: Optional[Union[int, str, bytes]]) -> Transactio
 def _get_transaction_cls(transaction_type: TransactionType) -> Type[TransactionAPI]:
     transaction_types = {
         TransactionType.STATIC: StaticFeeTransaction,
-        TransactionType.DYNAMIC: DynamicFeeTransaction
+        TransactionType.DYNAMIC: DynamicFeeTransaction,
     }
     if transaction_type not in transaction_types:
         raise ApeArbitrumError(f"Transaction type '{transaction_type}' not supported.")


### PR DESCRIPTION
Fixes #9 

```
In [1]: tx_hash = '0x452398f3a8c63d2b525d96972c64e0f3e732ce8f2d7aac7ff0400ef79b96e25d'

In [2]: decoded = str(networks.provider.get_receipt(tx_hash).transaction.data.hex())

In [3]: decoded = str(networks.provider.get_receipt(tx_hash).transaction.data.hex())

In [4]: decoded
Out[4]: '2e1a7d4d0000000000000000000000000000000000000000000000000000000031f59bbd'
```