### PR TITLE
feat: stop estimating gas in tests [APE-1020]

### DIFF
--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -5,6 +5,7 @@ from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import ApeException
 from ape.types import TransactionSignature
+from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
 from eth_typing import HexStr
@@ -31,9 +32,13 @@ def _create_network_config(
     )
 
 
-def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfig:
+def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:
     return _create_network_config(
-        required_confirmations=0, block_time=0, default_provider=default_provider
+        required_confirmations=0,
+        default_provider=default_provider,
+        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        gas_limit="max",
+        **kwargs,
     )
 
 

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -8,8 +8,7 @@ from ape.types import TransactionSignature
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
-from eth_typing import HexStr
-from eth_utils import add_0x_prefix, decode_hex
+from eth_utils import decode_hex
 
 NETWORKS = {
     # chain_id, network_id

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -67,7 +67,7 @@ class Arbitrum(Ethereum):
             :class:`~ape.api.transactions.TransactionAPI`
         """
 
-        transaction_type = _get_transaction_type(kwargs.get("type"))
+        transaction_type = self.get_transaction_type(kwargs.get("type"))
         kwargs["type"] = transaction_type.value
         txn_class = _get_transaction_cls(transaction_type)
 
@@ -95,23 +95,14 @@ class Arbitrum(Ethereum):
 
         return txn_class.parse_obj(kwargs)
 
-
-def _get_transaction_type(_type: Optional[Union[int, str, bytes]]) -> TransactionType:
-    if not _type:
-        return TransactionType.STATIC
-
-    if _type is None:
-        _type = TransactionType.STATIC.value
-    elif isinstance(_type, int):
-        _type = f"0{_type}"
-    elif isinstance(_type, bytes):
-        _type = _type.hex()
-
-    suffix = _type.replace("0x", "")
-    if len(suffix) == 1:
-        _type = f"{_type.rstrip(suffix)}0{suffix}"
-
-    return TransactionType(add_0x_prefix(HexStr(_type)))
+    def get_transaction_type(self, _type: Optional[Union[int, str, bytes]]) -> TransactionType:
+        if _type is None:
+            version = TransactionType.STATIC
+        elif not isinstance(_type, int):
+            version = TransactionType(self.conversion_manager.convert(_type, int))
+        else:
+            version = TransactionType(_type)
+        return version
 
 
 def _get_transaction_cls(transaction_type: TransactionType) -> Type[TransactionAPI]:

--- a/setup.py
+++ b/setup.py
@@ -88,5 +88,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,8 @@ def accounts():
 @pytest.fixture
 def Contract():
     return ape.Contract
+
+
+@pytest.fixture
+def arbitrum(networks):
+    return networks.arbitrum

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -9,6 +9,6 @@ def test_gas_limit(networks):
 
 @pytest.mark.parametrize("type", (0, "0x0"))
 def test_create_transaction(networks, type):
-    optimism = networks.optimism
+    optimism = networks.arbitrum
     txn = optimism.create_transaction(type=type)
     assert txn.type == TransactionType.STATIC.value

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -1,0 +1,3 @@
+def test_gas_limit(networks):
+    arbitrum = networks.arbitrum
+    assert arbitrum.config.local.gas_limit == "max"

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -1,3 +1,14 @@
+import pytest
+from ape_ethereum.transactions import TransactionType
+
+
 def test_gas_limit(networks):
     arbitrum = networks.arbitrum
     assert arbitrum.config.local.gas_limit == "max"
+
+
+@pytest.mark.parametrize("type", (0, "0x0"))
+def test_create_transaction(networks, type):
+    optimism = networks.optimism
+    txn = optimism.create_transaction(type=type)
+    assert txn.type == TransactionType.STATIC.value

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -2,13 +2,11 @@ import pytest
 from ape_ethereum.transactions import TransactionType
 
 
-def test_gas_limit(networks):
-    arbitrum = networks.arbitrum
+def test_gas_limit(arbitrum):
     assert arbitrum.config.local.gas_limit == "max"
 
 
 @pytest.mark.parametrize("type", (0, "0x0"))
-def test_create_transaction(networks, type):
-    optimism = networks.arbitrum
-    txn = optimism.create_transaction(type=type)
+def test_create_transaction(arbitrum, type):
+    txn = arbitrum.create_transaction(type=type)
     assert txn.type == TransactionType.STATIC.value


### PR DESCRIPTION
### What I did

Follow changes from `ape-ethereum` and stop estimating gas in tests

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
