### PR TITLE
refactor: remove goerli

### DIFF
--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -20,7 +20,6 @@ from pydantic.fields import Field
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (42161, 42161),
-    "goerli": (421613, 421613),
     "sepolia": (421614, 421614),
 }
 INTERNAL_TRANSACTION_TYPE = 106
@@ -108,7 +107,6 @@ class ArbitrumConfig(BaseEthereumConfig):
     DEFAULT_TRANSACTION_TYPE: ClassVar[int] = EthTransactionType.STATIC.value
     DEFAULT_LOCAL_GAS_LIMIT: ClassVar[GasLimit] = LOCAL_GAS_LIMIT
     mainnet: NetworkConfig = _create_config()
-    goerli: NetworkConfig = _create_config()
     sepolia: NetworkConfig = _create_config()
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,8 +6,6 @@ EXPECTED_OUTPUT = """
 arbitrum
 ├── mainnet
 │   └── geth  (default)
-├── goerli
-│   └── geth  (default)
 ├── sepolia
 │   └── geth  (default)
 └── local  (default)
@@ -49,7 +47,6 @@ def assert_rich_text(actual: str, expected: str):
 def test_networks(runner, cli, arbitrum):
     # Do this in case local env changed it.
     arbitrum.mainnet.set_default_provider("geth")
-    arbitrum.goerli.set_default_provider("geth")
     arbitrum.sepolia.set_default_provider("geth")
 
     result = runner.invoke(cli, ["networks", "list"])


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
