### PR TITLE
fix: for APE-1796, adds in gas_used_for_L1 to arbitrum receipt

### DIFF
--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -40,7 +40,7 @@ class ApeArbitrumError(ApeException):
 
 
 class ArbitrumReceipt(Receipt):
-    gas_used_for_L1: HexInt
+    gas_used_for_L1: HexInt = Field(alias="gasUsedForL1")
 
     def await_confirmations(self) -> "ReceiptAPI":
         """

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -259,7 +259,7 @@ class Arbitrum(Ethereum):
             gas_limit=data.get("gas", data.get("gas_limit", data.get("gasLimit"))) or 0,
             gas_price=data.get("gas_price", data.get("gasPrice")) or 0,
             gas_used=data.get("gas_used", data.get("gasUsed")) or 0,
-            gas_used_for_L1=data.get("gas_used_for_L1", data.get("gasUsedForL1")) or 0,
+            gasUsedForL1=data.get("gas_used_for_L1", data.get("gasUsedForL1")) or 0,
             logs=data.get("logs", []),
             status=status,
             txn_hash=txn_hash,

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -40,7 +40,7 @@ class ApeArbitrumError(ApeException):
 
 
 class ArbitrumReceipt(Receipt):
-    gas_used_for_L1: HexInt = Field(alias="gasUsedForL1")
+    gas_used_for_L1: HexInt = Field(default=0, alias="gasUsedForL1")
 
     def await_confirmations(self) -> "ReceiptAPI":
         """

--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -4,7 +4,7 @@ from typing import ClassVar, cast
 from ape.api.transactions import ConfirmationsProgressBar, ReceiptAPI, TransactionAPI
 from ape.exceptions import ApeException, TransactionError
 from ape.logging import logger
-from ape.types import GasLimit, TransactionSignature
+from ape.types import GasLimit, HexInt, TransactionSignature
 from ape_ethereum.ecosystem import BaseEthereumConfig, Ethereum, NetworkConfig
 from ape_ethereum.transactions import (
     AccessListTransaction,
@@ -40,6 +40,8 @@ class ApeArbitrumError(ApeException):
 
 
 class ArbitrumReceipt(Receipt):
+    gas_used_for_L1: HexInt
+
     def await_confirmations(self) -> "ReceiptAPI":
         """
         Overridden to handle skipping nonce-check for internal txns.
@@ -257,6 +259,7 @@ class Arbitrum(Ethereum):
             gas_limit=data.get("gas", data.get("gas_limit", data.get("gasLimit"))) or 0,
             gas_price=data.get("gas_price", data.get("gasPrice")) or 0,
             gas_used=data.get("gas_used", data.get("gasUsed")) or 0,
+            gas_used_for_L1=data.get("gas_used_for_L1", data.get("gasUsedForL1")) or 0,
             logs=data.get("logs", []),
             status=status,
             txn_hash=txn_hash,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 max-line-length = 100
 exclude =
+	.venv*
 	venv*
 	.eggs
 	docs

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -103,3 +103,6 @@ def test_decode_receipt(arbitrum):
     }
     actual = arbitrum.decode_receipt(data)
     assert isinstance(actual, ArbitrumReceipt)
+
+    # Check that the receipt decodes HexInt correctly
+    assert actual.gas_used_for_L1 == 0

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -99,10 +99,10 @@ def test_decode_receipt(arbitrum):
         ),
         "status": 1,
         "l1BlockNumber": "0x11148fc",
-        "gasUsedForL1": "0x0",
+        "gasUsedForL1": "0x7",
     }
     actual = arbitrum.decode_receipt(data)
     assert isinstance(actual, ArbitrumReceipt)
 
     # Check that the receipt decodes HexInt correctly
-    assert actual.gas_used_for_L1 == 0
+    assert actual.gas_used_for_L1 == 7


### PR DESCRIPTION
### What I did
Added in the gas_used_for_L1 arbitrum property to the ape receipt

fixes: APE-1796

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
