### PR TITLE
perf: plugin load time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.0
+    rev: v1.13.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]

--- a/ape_arbitrum/__init__.py
+++ b/ape_arbitrum/__init__.py
@@ -1,23 +1,31 @@
 from ape import plugins
-from ape.api.networks import LOCAL_NETWORK_NAME, ForkedNetworkAPI, NetworkAPI, create_network_type
-from ape_node import Node
-from ape_test import LocalProvider
-
-from .ecosystem import NETWORKS, Arbitrum, ArbitrumConfig
 
 
 @plugins.register(plugins.Config)
 def config_class():
+    from .ecosystem import ArbitrumConfig
+
     return ArbitrumConfig
 
 
 @plugins.register(plugins.EcosystemPlugin)
 def ecosystems():
+    from .ecosystem import Arbitrum
+
     yield Arbitrum
 
 
 @plugins.register(plugins.NetworkPlugin)
 def networks():
+    from ape.api.networks import (
+        LOCAL_NETWORK_NAME,
+        ForkedNetworkAPI,
+        NetworkAPI,
+        create_network_type,
+    )
+
+    from .ecosystem import NETWORKS
+
     for network_name, network_params in NETWORKS.items():
         yield "arbitrum", network_name, create_network_type(*network_params)
         yield "arbitrum", f"{network_name}-fork", ForkedNetworkAPI
@@ -28,7 +36,19 @@ def networks():
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
+    from ape.api.networks import LOCAL_NETWORK_NAME
+    from ape_node import Node
+    from ape_test import LocalProvider
+
+    from .ecosystem import NETWORKS
+
     for network_name in NETWORKS:
         yield "arbitrum", network_name, Node
 
     yield "arbitrum", LOCAL_NETWORK_NAME, LocalProvider
+
+
+def __getattr__(name: str):
+    import ape_arbitrum.ecosystem as module
+
+    return getattr(module, name)

--- a/ape_arbitrum/__init__.py
+++ b/ape_arbitrum/__init__.py
@@ -52,3 +52,10 @@ def __getattr__(name: str):
     import ape_arbitrum.ecosystem as module
 
     return getattr(module, name)
+
+
+__all__ = [
+    "NETWORKS",
+    "Arbitrum",
+    "ArbitrumConfig",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,10 @@
 [flake8]
 max-line-length = 100
-ignore = E704,W503,PYD002
+ignore = E704,W503,PYD002,TC003,TC006
 exclude =
 	.venv*
 	venv*
 	.eggs
 	docs
 	build
+type-checking-pydantic-enabled = True

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ extras_require = {
         "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
+        "flake8-pydantic",  # For detecting issues with Pydantic models
+        "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
         "isort>=5.13.2,<6",  # Import sorting linter
         "mdformat>=0.7.1",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
     ],
     "lint": [
         "black>=24.10.0,<25",  # Auto-formatter and linter
-        "mypy>=1.12.0,<2",  # Static type analyzer
+        "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code


### PR DESCRIPTION
### What I did

Before:

```
In [1]: %time import ape_arbitrum
CPU times: user 1.81 s, sys: 183 ms, total: 1.99 s
Wall time: 2.02 s
```

After:

```
CPU times: user 7.89 ms, sys: 3.25 ms, total: 11.1 ms
Wall time: 13.1 ms
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
