### PR TITLE
fix: declare nova networks as a mainnet

### DIFF
--- a/ape_arbitrum/ecosystem.py
+++ b/ape_arbitrum/ecosystem.py
@@ -111,7 +111,7 @@ class ArbitrumConfig(BaseEthereumConfig):
     DEFAULT_LOCAL_GAS_LIMIT: ClassVar[GasLimit] = LOCAL_GAS_LIMIT
     mainnet: NetworkConfig = _create_config()
     sepolia: NetworkConfig = _create_config()
-    nova: NetworkConfig = _create_config()
+    nova: NetworkConfig = _create_config(is_mainnet=True)
 
 
 class Arbitrum(Ethereum):

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -106,3 +106,9 @@ def test_decode_receipt(arbitrum):
 
     # Check that the receipt decodes HexInt correctly
     assert actual.gas_used_for_L1 == 7
+
+
+def test_is_mainnet(arbitrum):
+    assert arbitrum.mainnet.is_mainnet
+    assert arbitrum.nova.is_mainnet
+    assert not arbitrum.sepolia.is_mainnet


### PR DESCRIPTION
### What I did

nova is a not a testnet, so the same care with any mainnet should apply, which is granted from this one simple setting

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
